### PR TITLE
(fix) Added cordova whitelist plugin and config.xml entries

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -10,6 +10,7 @@
   <icon src="www/images/app_icon.png"/>
   <content src="index.html"/>
   <access origin="*"/>
+  <allow-navigation href="http://*/*" />
   <preference name="webviewbounce" value="false"/>
   <preference name="UIWebViewBounce" value="false"/>
   <preference name="DisallowOverscroll" value="true"/>

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
     "org.apache.cordova.contacts",
     "https://github.com/aharris88/phonegap-sms-plugin.git",
     "https://github.com/phpsa/cbsp.git",
-    "https://github.com/katzer/cordova-plugin-background-mode.git"
+    "https://github.com/katzer/cordova-plugin-background-mode.git",
+    "https://github.com/apache/cordova-plugin-whitelist.git"
+  ],
+  "cordovaPlatforms": [
+    "android"
   ]
 }


### PR DESCRIPTION
The app should now be able to make ajax requests.
A cordova plugin was added to allow proper navigation and request handling to external domains
Proper entries were made in the config.xml to according to https://github.com/apache/cordova-plugin-whitelist
